### PR TITLE
Add standalone web client for signal recording and visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Tested with **Python 3.10+**
 
    Visit [http://localhost:8080](http://localhost:8080) to use the web-based interface.
 
+## 🌐 Static Web Demo
+
+A lightweight front-end version is available in the `web` directory. Open `web/index.html` in a modern browser to record audio, visualize time and frequency domains, and play back recordings without running the Python server.
+
 ## 📂 File Structure
 
 ```bash
@@ -67,6 +71,9 @@ SonicScope/
 ├── assets/                # Audio files (input/output WAV)
 │   ├── input.wav
 │   └── output.wav
+├── web/                   # Standalone web client
+│   ├── index.html
+│   └── app.js
 ├── config.py              # Central config and shared plots
 ├── gui.py                 # NiceGUI front-end layout
 ├── signal_tools.py        # Recording, playback, upload, plotting
@@ -98,4 +105,3 @@ GitHub: [https://github.com/rh8991/signal-processing-roadmap](https://github.com
 ## 📄 License
 
 This project is licensed under the MIT License.
-# SonicScope-LITE

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,79 @@
+const recordBtn = document.getElementById('record');
+const stopBtn = document.getElementById('stop');
+const playBtn = document.getElementById('play');
+const player = document.getElementById('player');
+const waveformCanvas = document.getElementById('waveform');
+const freqCanvas = document.getElementById('frequency');
+const waveCtx = waveformCanvas.getContext('2d');
+const freqCtx = freqCanvas.getContext('2d');
+
+let mediaRecorder;
+let audioChunks = [];
+let analyser;
+let dataArray;
+let freqArray;
+let animationId;
+let audioCtx;
+let source;
+
+function draw() {
+    waveCtx.clearRect(0, 0, waveformCanvas.width, waveformCanvas.height);
+    freqCtx.clearRect(0, 0, freqCanvas.width, freqCanvas.height);
+
+    analyser.getByteTimeDomainData(dataArray);
+    analyser.getByteFrequencyData(freqArray);
+
+    waveCtx.beginPath();
+    for (let i = 0; i < dataArray.length; i++) {
+        const x = (i / dataArray.length) * waveformCanvas.width;
+        const y = (dataArray[i] / 255.0) * waveformCanvas.height;
+        if (i === 0) waveCtx.moveTo(x, y);
+        else waveCtx.lineTo(x, y);
+    }
+    waveCtx.stroke();
+
+    const barWidth = freqCanvas.width / freqArray.length;
+    for (let i = 0; i < freqArray.length; i++) {
+        const barHeight = freqArray[i] / 255.0 * freqCanvas.height;
+        freqCtx.fillRect(i * barWidth, freqCanvas.height - barHeight, barWidth, barHeight);
+    }
+
+    animationId = requestAnimationFrame(draw);
+}
+
+recordBtn.onclick = async () => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    audioCtx = new AudioContext();
+    source = audioCtx.createMediaStreamSource(stream);
+    analyser = audioCtx.createAnalyser();
+    source.connect(analyser);
+    analyser.fftSize = 2048;
+    const bufferLength = analyser.frequencyBinCount;
+    dataArray = new Uint8Array(bufferLength);
+    freqArray = new Uint8Array(bufferLength);
+
+    mediaRecorder = new MediaRecorder(stream);
+    mediaRecorder.ondataavailable = e => audioChunks.push(e.data);
+    mediaRecorder.onstop = () => {
+        const blob = new Blob(audioChunks, { type: 'audio/webm' });
+        audioChunks = [];
+        player.src = URL.createObjectURL(blob);
+        playBtn.disabled = false;
+    };
+    mediaRecorder.start();
+    draw();
+    recordBtn.disabled = true;
+    stopBtn.disabled = false;
+};
+
+stopBtn.onclick = () => {
+    mediaRecorder.stop();
+    cancelAnimationFrame(animationId);
+    audioCtx && audioCtx.close();
+    recordBtn.disabled = false;
+    stopBtn.disabled = true;
+};
+
+playBtn.onclick = () => {
+    player.play();
+};

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SonicScope Web</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; padding: 20px; }
+        canvas { border: 1px solid #ccc; width: 100%; height: 150px; }
+        #controls { margin-bottom: 10px; }
+    </style>
+</head>
+<body>
+    <h1>SonicScope Web</h1>
+    <div id="controls">
+        <button id="record">Record</button>
+        <button id="stop" disabled>Stop</button>
+        <button id="play" disabled>Play</button>
+    </div>
+    <audio id="player" controls></audio>
+    <h2>Time Domain</h2>
+    <canvas id="waveform" width="600" height="150"></canvas>
+    <h2>Frequency Domain</h2>
+    <canvas id="frequency" width="600" height="150"></canvas>
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add static web client that records microphone input, visualizes waveform and frequency spectrum, and plays back recordings
- document new web client in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6894a5b849688327984b0bc82ccc3e7f